### PR TITLE
feat: colorscale as HTML Canvas

### DIFF
--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -473,18 +473,16 @@ function ramp(color, n) {
   let container = d3.select('#colorScale');
   let canvas = container.append("canvas")
     .attr("height", n)
-    .attr("width", 40);
+    .attr("width", 1);
   let context = canvas.node().getContext("2d");
 
-  // canvas.style.margin = "0 -14px";
-  // canvas.style.height = "calc(100% + 28px)";
   canvas.style.width = "40px";
   canvas.style.imageRendering = "pixelated";
   for (let i = 0; i < n; ++i) {
     // only do this for actual colors
     if(color[i] !== undefined) {
       context.fillStyle = color[i]; // color[i / (n - 1)]
-      context.fillRect(0, i, 40, 1);
+      context.fillRect(0, i, 1, 1);
     }
   }
   return canvas;

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -467,6 +467,29 @@ function colorspaceOptions() {
   chart2dColorspace.value = 'CAM02';
 }
 
+// Ramp function to create HTML canvas color scale
+function ramp(color, n) {
+  n = window.innerHeight - 284;
+  let container = d3.select('#colorScale');
+  let canvas = container.append("canvas")
+    .attr("height", n)
+    .attr("width", 40);
+  let context = canvas.node().getContext("2d");
+
+  // canvas.style.margin = "0 -14px";
+  // canvas.style.height = "calc(100% + 28px)";
+  canvas.style.width = "40px";
+  canvas.style.imageRendering = "pixelated";
+  for (let i = 0; i < n; ++i) {
+    // only do this for actual colors
+    if(color[i] !== undefined) {
+      context.fillStyle = color[i]; // color[i / (n - 1)]
+      context.fillRect(0, i, 40, 1);
+    }
+  }
+  return canvas;
+}
+
 // Calculate Color and generate Scales
 window.colorInput = colorInput;
 function colorInput() {
@@ -512,6 +535,11 @@ function colorInput() {
 
   // Generate scale data so we have access to all 3000 swatches to draw the gradient on the left
   let scaleData = contrastColors.createScale({swatches: 3000, colorKeys: colorArgs, colorspace: mode, shift: shift});
+  let n = window.innerHeight - 282;
+  // let n = window.innerHeight - 84;
+  console.log(n);
+
+  let rampData = contrastColors.createScale({swatches: n, colorKeys: colorArgs, colorspace: mode, shift: shift});
 
   newColors = contrastColors.generateContrastColors({colorKeys: colorArgs, base: background, ratios: ratioInputs, colorspace: mode, shift: shift});
 
@@ -560,15 +588,9 @@ function colorInput() {
     swatch.style.backgroundColor = newColors[i];
   }
 
-  // Generate Gradient
-  for (let i = 0; i < scaleData.colors.length; i++) {
-    var container = document.getElementById('colorScale');
-    var div = document.createElement('div');
-    div.className = 'colorScale-Item';
-    div.style.backgroundColor = scaleData.colors[i];
-
-    container.appendChild(div);
-  }
+  // Generate Gradient as HTML Canvas element
+  let filteredColors = rampData.colors;
+  ramp(filteredColors, n);
 
   var backgroundR = d3.rgb(background).r;
   var backgroundG = d3.rgb(background).g;


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/contrast/issues
   - If there's no issue, file it: https://github.com/adobe/contrast/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
Color scale is now being generated using a `ramp()` function to generate an HTML Canvas object, similar to how it's done with Observable examples in D3 documentation.

## Motivation
<!-- How do your changes support this project's goals? -->
HTML Canvas is widely supported and may fix color scale rendering issues 

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
