### PR TITLE
feat(ui): Increment ratio input by whole number when Shift is pressed

### DIFF
--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -171,6 +171,7 @@ function addRatio(v, s = '#cacaca') {
   input.placeholder = 4.5;
   input.id = randId;
   input.value = v;
+  input.onkeydown = checkRatioStepModifiers;
   input.oninput = colorInput;
   var button = document.createElement('button');
   button.className = 'spectrum-ActionButton spectrum-ActionButton--quiet';
@@ -486,6 +487,27 @@ function ramp(color, n) {
     }
   }
   return canvas;
+}
+
+function checkRatioStepModifiers(e) {
+  if (!e.shiftKey) return;
+  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+  e.preventDefault()
+  const value = Number(e.target.value)
+  let newValue;
+  switch (e.key) {
+    case 'ArrowDown':
+      newValue = value - 1;
+      e.target.value = newValue.toFixed(2)
+      e.target.oninput()
+      break;
+    case 'ArrowUp':
+      newValue = value + 1;
+      e.target.value = newValue.toFixed(2)
+      e.target.oninput()
+      break;
+    default:
+  }
 }
 
 // Calculate Color and generate Scales

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -492,19 +492,19 @@ function ramp(color, n) {
 function checkRatioStepModifiers(e) {
   if (!e.shiftKey) return;
   if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
-  e.preventDefault()
-  const value = Number(e.target.value)
+  e.preventDefault();
+  const value = Number(e.target.value);
   let newValue;
   switch (e.key) {
     case 'ArrowDown':
       newValue = value - 1;
-      e.target.value = newValue.toFixed(2)
-      e.target.oninput()
+      e.target.value = newValue.toFixed(2);
+      e.target.oninput();
       break;
     case 'ArrowUp':
       newValue = value + 1;
-      e.target.value = newValue.toFixed(2)
-      e.target.oninput()
+      e.target.value = newValue.toFixed(2);
+      e.target.oninput();
       break;
     default:
   }


### PR DESCRIPTION
# Description
When `Shift` is held, pressing `ArrowUp`/`ArrowDown` inside a contrast ratio input will adjust the ratio by `1`, instead of `0.1`

Closes #4 

## Motivation
Speeds up the process of adjusting contrast ratios by keyboard.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
