### PR TITLE
docs: Fix link in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a detailed walkthrough of Leonardo, [check out this article](https://medium.
 ## Project Goals
 To make it easier for designers and engineers to leverage color science to create custom interpolations for a value scale, and to make it easier for designers and engineers to conform to [WCAG minimum contrast standards](https://www.w3.org/TR/WCAG21/#contrast-minimum) by using contrast ratio as the starting point, rather than a post-color-selection auditing process.
 
-1. [Leonardo web application](leonardo-web-application)
+1. [Leonardo web application](#leonardo-web-application)
 2. [Show me a demo](#show-me-a-demo)
 3. [What is "adaptive color"?](#what-is-adaptive-color)
 4. [Using Leonardo](#using-leonardo)


### PR DESCRIPTION

<!-- Summarize your changes in the Title field -->

## Description
The first link "Leonardo web application" in the table of contents was not pointing to the in-page anchor (#leonardo-web-application) because of a missing `#` sign.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
