### PR TITLE
fix: corrected midtone color outputs

### DIFF
--- a/packages/contrast-colors/index.js
+++ b/packages/contrast-colors/index.js
@@ -214,25 +214,24 @@ function generateContrastColors({
   let swatches = 3000;
 
   let scaleData = createScale({swatches: swatches, colorKeys: colorKeys, colorspace: colorspace, shift: 1});
+  let baseV = (d3.hsluv(base).v) / 100;
 
   let Contrasts = d3.range(swatches).map((d) => {
     let rgbArray = [d3.rgb(scaleData.scale(d)).r, d3.rgb(scaleData.scale(d)).g, d3.rgb(scaleData.scale(d)).b];
     let baseRgbArray = [d3.rgb(base).r, d3.rgb(base).g, d3.rgb(base).b];
-    let ca = contrast(rgbArray, baseRgbArray).toFixed(2);
+    let ca = contrast(rgbArray, baseRgbArray, baseV).toFixed(2);
 
     return Number(ca);
   });
 
   let contrasts = Contrasts.filter(el => el != null);
 
-  let baseLum = luminance(d3.rgb(base).r, d3.rgb(base).g, d3.rgb(base).b);
-
   let newColors = [];
   ratios = ratios.map(Number);
 
   // Return color matching target ratio, or closest number
   for (let i=0; i < ratios.length; i++){
-    let r = binarySearch(contrasts, ratios[i], baseLum);
+    let r = binarySearch(contrasts, ratios[i], baseV);
     newColors.push(d3.rgb(scaleData.colors[r]).hex());
   }
 
@@ -248,20 +247,19 @@ function luminance(r, g, b) {
   });
   return (a[0] * 0.2126) + (a[1] * 0.7152) + (a[2] * 0.0722);
 }
-
+window.luminance = luminance;
 // function percievedLum(r, g, b) {
 //   return (0.299*r + 0.587*g + 0.114*b);
 // }
 
-// Separate files in a lib folder as well.
-function contrast(color, base) {
+function contrast(color, base, baseV) {
   let colorLum = luminance(color[0], color[1], color[2]);
   let baseLum = luminance(base[0], base[1], base[2]);
 
   let cr1 = (colorLum + 0.05) / (baseLum + 0.05);
   let cr2 = (baseLum + 0.05) / (colorLum + 0.05);
 
-  if (baseLum < 0.5) {
+  if (baseV < 0.5) {
     if (cr1 >= 1) {
       return cr1;
     }

--- a/packages/contrast-colors/index.js
+++ b/packages/contrast-colors/index.js
@@ -247,7 +247,7 @@ function luminance(r, g, b) {
   });
   return (a[0] * 0.2126) + (a[1] * 0.7152) + (a[2] * 0.0722);
 }
-window.luminance = luminance;
+
 // function percievedLum(r, g, b) {
 //   return (0.299*r + 0.587*g + 0.114*b);
 // }

--- a/packages/contrast-colors/test/generateContrastColors.test.js
+++ b/packages/contrast-colors/test/generateContrastColors.test.js
@@ -99,6 +99,28 @@ test('should generate black when negative ratio lighter than available colors', 
   expect(colors).toEqual([ '#000000' ]);
 });
 
+// Mid-Tone Backgrounds
+test('should generate slightly lighter & darker grays on a darker midtone gray background', function() {
+  let colors = generateContrastColors({colorKeys: ['#000000'], base: "#737373",ratios: [1.2, -1.2], colorspace: "LCH"}); // positive & negative ratios
+
+  expect(colors).toEqual([ '#808080', '#666666' ]);
+});
+test('should generate slightly lighter & darker grays on a lighter midtone gray background', function() {
+  let colors = generateContrastColors({colorKeys: ['#000000'], base: "#787878",ratios: [1.2, -1.2], colorspace: "LCH"}); // positive & negative ratios
+
+  expect(colors).toEqual([ '#6b6b6b', '#858585' ]);
+});
+test('should generate slightly lighter & darker oranges on a darker midtone slate background', function() {
+  let colors = generateContrastColors({colorKeys: ["#ff8602","#ab3c00","#ffd88b"], base: "#537a9c",ratios: [1.2, -1.2], colorspace: "LCH"}); // positive & negative ratios
+
+  expect(colors).toEqual([ '#d66102', '#b64601' ]);
+});
+test('should generate slightly lighter & darker oranges on a lighter midtone slate background', function() {
+  let colors = generateContrastColors({colorKeys: ["#ff8602","#ab3c00","#ffd88b"], base: "#537b9d",ratios: [1.2, -1.2], colorspace: "LCH"}); // positive & negative ratios
+
+  expect(colors).toEqual([ '#b84601', '#d76202' ]);
+});
+
 // Expected errors
 test('should generate no colors, missing colorKeys', function() {
   expect(


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
Lighter midtone base colors were outputting pure _white_ for the generated colors when they should be outputting _color_.

Switched from using *relative luminance* as the measure of base color's brightness to a more perceptually uniform lightness value in HSLuv. Both are measured as 0-1 or 0-100 (such as percent), however the mid-value of each is very different. Perceptually, 50% should be the mid-mark, however this is not the case for relative luminance. Chart shows HSLuv value for a set of random colors (blue) vs the relative luminance of those same colors (orange) with a mid-tone mark at 50%
![image](https://user-images.githubusercontent.com/13972198/72824320-4dd41f00-3c32-11ea-97d3-42fb0d83aa53.png)

The 50% mark is not the sole motivation for switching to HSLuv lightness for calculating when to switch directionality of ratios, but also due to the inaccuracy of the relative luminance formula and the confidence level that is present with the perceptive luminance of colors in HSLuv space.

Specific changes:
1. In `contrast()` function, `baseV` argument can be passed. BaseV is used rather than originally calculating the luminance of the base color as the condition.
2. In `generateContrastColors()` function, `baseV` is defined as the base color's HSLuv lightness value and passed to the contrasts mapping function. 
3. In `generateContrastColors()` function, `baseV` is passed through the binary search function rather than the luminance of the base color.
4. Added tests for bidirectional contrast in lighter & darker midtone colors, right near the split between directionality of generated colors. Tests for pure gray as well as tests for generating orange colors on a slate blue background.

Fixes #31 

## Motivation
<!-- How do your changes support this project's goals? -->
Fix bugs

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
<img width="1118" alt="Screen Shot 2020-01-21 at 9 33 52 AM" src="https://user-images.githubusercontent.com/13972198/72824837-30538500-3c33-11ea-88b1-80951fedc12d.png">
<img width="1120" alt="Screen Shot 2020-01-21 at 9 34 04 AM" src="https://user-images.githubusercontent.com/13972198/72824838-30538500-3c33-11ea-9e80-dcd1446ecce8.png">
<img width="1117" alt="Screen Shot 2020-01-21 at 9 34 35 AM" src="https://user-images.githubusercontent.com/13972198/72824841-30ec1b80-3c33-11ea-8866-2802950af9d4.png">
<img width="1117" alt="Screen Shot 2020-01-21 at 9 34 51 AM" src="https://user-images.githubusercontent.com/13972198/72824842-30ec1b80-3c33-11ea-8855-9c74c90b08ab.png">


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
