### PR TITLE
Added smooth interpolation

### DIFF
--- a/packages/contrast-colors/curve.js
+++ b/packages/contrast-colors/curve.js
@@ -1,0 +1,109 @@
+const base3 = (t, p1, p2, p3, p4) => {
+    const t1 = -3 * p1 + 9 * p2 - 9 * p3 + 3 * p4,
+          t2 = t * t1 + 6 * p1 - 12 * p2 + 6 * p3;
+    return t * t2 - 3 * p1 + 3 * p2;
+}
+export const bezlen = (x1, y1, x2, y2, x3, y3, x4, y4, z) => {
+    if (z == null) {
+        z = 1;
+    }
+    z = z > 1 ? 1 : z < 0 ? 0 : z;
+    var z2 = z / 2,
+        n = 12,
+        Tvalues = [-.1252,.1252,-.3678,.3678,-.5873,.5873,-.7699,.7699,-.9041,.9041,-.9816,.9816],
+        Cvalues = [0.2491,0.2491,0.2335,0.2335,0.2032,0.2032,0.1601,0.1601,0.1069,0.1069,0.0472,0.0472],
+        sum = 0;
+    for (var i = 0; i < n; i++) {
+        var ct = z2 * Tvalues[i] + z2,
+            xbase = base3(ct, x1, x2, x3, x4),
+            ybase = base3(ct, y1, y2, y3, y4),
+            comb = xbase * xbase + ybase * ybase;
+        sum += Cvalues[i] * Math.sqrt(comb);
+    }
+    return z2 * sum;
+}
+export const findDotsAtSegment = (p1x, p1y, c1x, c1y, c2x, c2y, p2x, p2y, t) => {
+    const t1 = 1 - t,
+        t12 = t1 * t1,
+        t13 = t12 * t1,
+        t2 = t * t,
+        t3 = t2 * t,
+        x = t13 * p1x + t12 * 3 * t * c1x + t1 * 3 * t * t * c2x + t3 * p2x,
+        y = t13 * p1y + t12 * 3 * t * c1y + t1 * 3 * t * t * c2y + t3 * p2y;
+    return {
+        x: x,
+        y: y
+    };
+}
+export const catmullRom2bezier = (crp, z) => {
+    const d = [];
+    let end = {x: +crp[0], y: +crp[1]};
+    for (let i = 0, iLen = crp.length; iLen - 2 * !z > i; i += 2) {
+        const p = [
+            {x: +crp[i - 2], y: +crp[i - 1]},
+            {x: +crp[i],     y: +crp[i + 1]},
+            {x: +crp[i + 2], y: +crp[i + 3]},
+            {x: +crp[i + 4], y: +crp[i + 5]}
+        ];
+        if (z) {
+            if (!i) {
+                p[0] = {x: +crp[iLen - 2], y: +crp[iLen - 1]};
+            } else if (iLen - 4 == i) {
+                p[3] = {x: +crp[0], y: +crp[1]};
+            } else if (iLen - 2 == i) {
+                p[2] = {x: +crp[0], y: +crp[1]};
+                p[3] = {x: +crp[2], y: +crp[3]};
+            }
+        } else {
+            if (iLen - 4 == i) {
+                p[3] = p[2];
+            } else if (!i) {
+                p[0] = {x: +crp[i], y: +crp[i + 1]};
+            }
+        }
+        d.push([
+            end.x,
+            end.y,
+            (-p[0].x + 6 * p[1].x + p[2].x) / 6,
+            (-p[0].y + 6 * p[1].y + p[2].y) / 6,
+            (p[1].x + 6 * p[2].x - p[3].x) / 6,
+            (p[1].y + 6 * p[2].y - p[3].y) / 6,
+            p[2].x,
+            p[2].y
+        ]);
+        end = p[2];
+    }
+
+    return d;
+}
+
+export const prepareCurve = (p1x, p1y, c1x, c1y, c2x, c2y, p2x, p2y) => {
+  const len = Math.floor(bezlen(p1x, p1y, c1x, c1y, c2x, c2y, p2x, p2y) * .75);
+  const map = new Map;
+  for (let i = 0; i <= len; i++) {
+    const t = i / len;
+    map.set(t, findDotsAtSegment(p1x, p1y, c1x, c1y, c2x, c2y, p2x, p2y, t));
+  }
+  return x => {
+    const keys = Array.from(map.keys());
+    let p = map.get(keys[0]);
+    const last = map.get(keys[keys.length - 1]);
+    if (x < p.x || x > last.x) {
+      return null;
+    }
+    for (let i = 0; i < keys.length; i++) {
+      const value = map.get(keys[i]);
+      if (value.x >= x) {
+        const x1 = p.x;
+        const x2 = value.x;
+        const y1 = p.y;
+        const y2 = value.y;
+        if (!i) {
+          return y2;
+        }
+        return (x - x1) * (y2 - y1) / (x2 - x1) + y1;
+      }
+      p = value;
+    }
+  };
+};

--- a/packages/contrast-colors/index.js
+++ b/packages/contrast-colors/index.js
@@ -183,7 +183,9 @@ const colorSpaces = {
   LCH: {
     name: 'hcl',
     channels: ['h', 'c', 'l'],
-    interpolator: d3.interpolateHcl
+    interpolator: d3.interpolateHcl,
+    white: d3.hcl(NaN, 0, 100),
+    black: d3.hcl(NaN, 0, 0)
   },
   LAB: {
     name: 'lab',
@@ -198,7 +200,9 @@ const colorSpaces = {
   HSLuv: {
     name: 'hsluv',
     channels: ['l', 'u', 'v'],
-    interpolator: d3.interpolateHsluv
+    interpolator: d3.interpolateHsluv,
+    white: d3.hsluv(NaN, NaN, 100),
+    black: d3.hsluv(NaN, NaN, 0)
   },
   RGB: {
     name: 'rgb',
@@ -291,7 +295,7 @@ function createScale({
 
   let scale;
   if (fullScale) {
-    ColorsArray = ['#fff', ...sortedColor, '#000'];
+    ColorsArray = [space.white || '#fff', ...sortedColor, space.black || '#000'];
   } else {
     ColorsArray = sortedColor;
   }


### PR DESCRIPTION
• added `d3.interpolateJch`
• moved color spaces into `colorSpaces` const
• added `CAM02p` color space
• added curve.js with bezier functions
• added `smoothScale` function
• added `smooth` as a parameter to `createScale` function, `true` by default

## Description
Addressing smooth interpolation using Catmull Rom cubic bezier. Issue #5. The smoothness is on by default. It had to be plugged to the UI as some kind of a checkbox.

## Motivation
<!-- How do your changes support this project's goals? -->
Makes interpolation smoother


## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
Current interpolation model chart:
<img width="366" alt="Screen Shot 2020-03-04 at 11 43 35 am" src="https://user-images.githubusercontent.com/22726/75845640-d814c300-5e2d-11ea-8897-b274350d77b0.png">
The same colors interpolation model chart after PR applied:
<img width="289" alt="Screen Shot 2020-03-04 at 11 43 42 am" src="https://user-images.githubusercontent.com/22726/75845687-fe3a6300-5e2d-11ea-94cc-b82fa2473236.png">


## To-do list

- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
- [x] This pull request is ready to merge.
