### PR TITLE
Output format

### DIFF
--- a/packages/contrast-colors/README.md
+++ b/packages/contrast-colors/README.md
@@ -74,6 +74,21 @@ Optional value from 0-100 indicating the brightness of the base / background col
 #### `contrast` *integer*:
 Optional value to increase contrast of your generated colors. This value is multiplied against all ratios defined for each color scale.
 
+#### `output` *string (enum)*:
+String value of the desired color space and output format for the generated colors. Output formats conform to the [W3C CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/) spec for the supported options.
+
+| Output option | Sample value |
+|---------------|--------------|
+| `'HEX'`  _(default)_ | `#RRGGBB` |
+| `'RGB'`       | `rgb(255, 255, 255)` |
+| `'HSL'`       | `hsl(360deg, 0%, 100%)` |
+| `'HSV'`       | `hsv(360deg, 0%, 100%)` |
+| `'HSLuv'`     | `hsluv(360, 0, 100)` |
+| `'LAB'`       | `lab(100%, 0, 0)` |
+| `'LCH'`       | `lch(100%, 0, 360deg)` |
+| `'CAM02'`     | `jab(100%, 0, 0)`|
+| `'CAM02p'`    | `jch(100%, 0, 360deg)` |
+
 #### Output
 The `generateAdaptiveTheme` function returns an array of color objects. Each key is named by concatenating the user-defined color name (above) with a numeric value.
 

--- a/packages/contrast-colors/README.md
+++ b/packages/contrast-colors/README.md
@@ -89,7 +89,8 @@ String value of the desired color space and output format for the generated colo
 | `'CAM02'`     | `jab(100%, 0, 0)`|
 | `'CAM02p'`    | `jch(100%, 0, 360deg)` |
 
-#### Output
+
+#### `generateAdaptiveTheme` sample outputs
 The `generateAdaptiveTheme` function returns an array of color objects. Each key is named by concatenating the user-defined color name (above) with a numeric value.
 
 Colors with a **positive contrast ratio** with the base (ie, 2:1) will be named in increments of 100. For example, `gray100`, `gray200`.

--- a/packages/contrast-colors/README.md
+++ b/packages/contrast-colors/README.md
@@ -90,7 +90,7 @@ String value of the desired color space and output format for the generated colo
 | `'CAM02p'`    | `jch(100%, 0, 360deg)` |
 
 
-#### `generateAdaptiveTheme` sample outputs
+#### Function outputs and examples
 The `generateAdaptiveTheme` function returns an array of color objects. Each key is named by concatenating the user-defined color name (above) with a numeric value.
 
 Colors with a **positive contrast ratio** with the base (ie, 2:1) will be named in increments of 100. For example, `gray100`, `gray200`.

--- a/packages/contrast-colors/index.js
+++ b/packages/contrast-colors/index.js
@@ -111,46 +111,60 @@ const colorSpaces = {
   CAM02: {
     name: 'jab',
     channels: ['J', 'a', 'b'],
-    interpolator: d3.interpolateJab
+    interpolator: d3.interpolateJab,
+    function: d3.jab
   },
   CAM02p: {
     name: 'jch',
     channels: ['J', 'C', 'h'],
-    interpolator: d3.interpolateJch
+    interpolator: d3.interpolateJch,
+    function: d3.jch
   },
   LCH: {
-    name: 'hcl',
+    name: 'lch', // named per correct color definition order
     channels: ['h', 'c', 'l'],
     interpolator: d3.interpolateHcl,
     white: d3.hcl(NaN, 0, 100),
-    black: d3.hcl(NaN, 0, 0)
+    black: d3.hcl(NaN, 0, 0),
+    function: d3.hcl
   },
   LAB: {
     name: 'lab',
     channels: ['l', 'a', 'b'],
-    interpolator: d3.interpolateLab
+    interpolator: d3.interpolateLab,
+    function: d3.lab
   },
   HSL: {
     name: 'hsl',
     channels: ['h', 's', 'l'],
-    interpolator: d3.interpolateHsl
+    interpolator: d3.interpolateHsl,
+    function: d3.hsl
   },
   HSLuv: {
     name: 'hsluv',
     channels: ['l', 'u', 'v'],
     interpolator: d3.interpolateHsluv,
     white: d3.hsluv(NaN, NaN, 100),
-    black: d3.hsluv(NaN, NaN, 0)
+    black: d3.hsluv(NaN, NaN, 0),
+    function: d3.hsluv
   },
   RGB: {
     name: 'rgb',
     channels: ['r', 'g', 'b'],
-    interpolator: d3.interpolateRgb
+    interpolator: d3.interpolateRgb,
+    function: d3.rgb
   },
   HSV: {
     name: 'hsv',
     channels: ['h', 's', 'v'],
-    interpolator: d3.interpolateHsv
+    interpolator: d3.interpolateHsv,
+    function: d3.hsv
+  },
+  HEX: {
+    name: 'hex',
+    channels: ['r', 'g', 'b'],
+    interpolator: d3.interpolateRgb,
+    function: d3.rgb
   }
 };
 
@@ -308,7 +322,8 @@ function generateContrastColors({
   base,
   ratios,
   colorspace = 'LAB',
-  smooth = false
+  smooth = false,
+  output = 'HEX'
 } = {}) {
   if (!base) {
     throw new Error(`Base is undefined`);
@@ -326,6 +341,10 @@ function generateContrastColors({
   }
   if (!ratios) {
     throw new Error(`Ratios are undefined`);
+  }
+  const outputFormat = colorSpaces[output];
+  if (!outputFormat) {
+    throw new Error(`Colorspace “${output}” not supported`);
   }
 
   let swatches = 3000;
@@ -349,10 +368,112 @@ function generateContrastColors({
   // Return color matching target ratio, or closest number
   for (let i=0; i < ratios.length; i++){
     let r = binarySearch(contrasts, ratios[i], baseV);
-    newColors.push(d3.rgb(scaleData.colors[r]).hex());
+
+    // use fixColorValue function to convert each color to the specified
+    // output format. 
+    newColors.push(fixColorValue(scaleData.colors[r], output));
+    
   }
 
   return newColors;
+}
+
+// Helper function to change any NaN to a zero
+function filterNaN(x) {
+  if(isNaN(x)) {
+    return 0;
+  } else {
+    return x;
+  }
+}
+
+// Helper function for rounding color values to whole numbers
+function fixColorValue(color, format, object = false) {
+  let colorObj = colorSpaces[format].function(color);
+  let propArray = colorSpaces[format].channels;
+
+  let newColorObj = {
+    [propArray[0]]: filterNaN(colorObj[propArray[0]]),
+    [propArray[1]]: filterNaN(colorObj[propArray[1]]),
+    [propArray[2]]: filterNaN(colorObj[propArray[2]])
+  }
+
+  // HSLuv
+  if (format === "HSLuv") {
+    for (let i = 0; i < propArray.length; i++) {
+
+      let roundedPct = Math.round(newColorObj[propArray[i]]);
+      newColorObj[propArray[i]] = roundedPct;
+    }
+  }
+  // LAB, LCH, JAB, JCH
+  else if (format === "LAB" || format === "LCH" || format === "CAM02" || format === "CAM02p") {
+    for (let i = 0; i < propArray.length; i++) {
+      let roundedPct = Math.round(newColorObj[propArray[i]]);
+
+      if (propArray[i] === "h" && !object) {
+        roundedPct = roundedPct + "deg";
+      }
+      if (propArray[i] === "l" && !object || propArray[i] === "J" && !object) {
+        roundedPct = roundedPct + "%";
+      }
+
+      newColorObj[propArray[i]] = roundedPct;
+      
+    }
+  }
+  else {
+    for (let i = 0; i < propArray.length; i++) {
+      if (propArray[i] === "s" || propArray[i] === "l" || propArray[i] === "v") {
+        // leave as decimal format
+        let roundedPct = parseFloat(newColorObj[propArray[i]].toFixed(2));
+        if(object) {
+          newColorObj[propArray[i]] = roundedPct;
+        }
+        else {
+          newColorObj[propArray[i]] = Math.round(roundedPct * 100) + "%";
+        }
+      }
+      else {
+        let roundedPct = parseFloat(newColorObj[propArray[i]].toFixed());
+        if (propArray[i] === "h" && !object) {
+          roundedPct = roundedPct + "deg";
+        } 
+        newColorObj[propArray[i]] = roundedPct;
+      }
+    }
+  }
+
+  let stringName = colorSpaces[format].name;
+  let stringValue;
+
+  if (format === "HEX") {
+    stringValue = d3.rgb(color).formatHex();
+  } else {
+    let str0, srt1, str2;
+    if (format === "LCH") {
+      // Have to force opposite direction of array index for LCH
+      // because d3 defines the channel order as "h, c, l" but we
+      // want the output to be in the correct format
+      str0 = newColorObj[propArray[2]] + ", ";
+      str1 = newColorObj[propArray[1]] + ", ";
+      str2 = newColorObj[propArray[0]];
+    }
+    else {
+      str0 = newColorObj[propArray[0]] + ", ";
+      str1 = newColorObj[propArray[1]] + ", ";
+      str2 = newColorObj[propArray[2]];
+    }
+
+    stringValue = stringName + "(" + str0 + str1 + str2 + ")";
+  }
+
+  if (object) { 
+    // return colorObj;
+    return newColorObj;
+  } else {
+    return stringValue;
+  }
 }
 
 function luminance(r, g, b) {
@@ -430,7 +551,13 @@ function ratioName(r) {
   return nArr;
 }
 
-function generateAdaptiveTheme({colorScales, baseScale, brightness, contrast = 1}) {
+function generateAdaptiveTheme({
+  colorScales, 
+  baseScale, 
+  brightness, 
+  contrast = 1,
+  output = 'HEX'
+}) {
   if (!baseScale) {
     throw new Error('baseScale is undefined');
   }
@@ -453,7 +580,7 @@ function generateAdaptiveTheme({colorScales, baseScale, brightness, contrast = 1
 
   if (brightness === undefined) {
     return function(brightness, contrast) {
-      return generateAdaptiveTheme({baseScale: baseScale, colorScales: colorScales, brightness: brightness, contrast: contrast});
+      return generateAdaptiveTheme({baseScale: baseScale, colorScales: colorScales, brightness: brightness, contrast: contrast, output: output});
     }
   }
   else {
@@ -505,7 +632,8 @@ function generateAdaptiveTheme({colorScales, baseScale, brightness, contrast = 1
         colorspace: colorScales[i].colorspace,
         ratios: ratios,
         base: bval,
-        smooth: smooth
+        smooth: smooth,
+        output: output
       });
 
       for (let i=0; i < outputColors.length; i++) {
@@ -576,5 +704,6 @@ module.exports = {
   generateContrastColors,
   minPositive,
   ratioName,
-  generateAdaptiveTheme
+  generateAdaptiveTheme,
+  fixColorValue
 };

--- a/packages/contrast-colors/test/fixColorValue.test.js
+++ b/packages/contrast-colors/test/fixColorValue.test.js
@@ -1,0 +1,142 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { fixColorValue } = require('../index.js');
+
+test('should return color object for HSL color', function() {
+  let result = fixColorValue('#2c66f1', 'HSL', true);;
+
+  expect(result).toEqual({ "h": 222, "s": 0.88, "l": 0.56});
+
+});
+
+test('should return string format for HSL color', function() {
+  let result = fixColorValue('#2c66f1', 'HSL');;
+
+  expect(result).toEqual('hsl(222deg, 88%, 56%)');
+
+});
+
+
+test('should return color object for RGB color', function() {
+  let result = fixColorValue('#2c66f1', 'RGB', true);;
+
+  expect(result).toEqual({ "r": 44, "g": 102, "b": 241});
+
+});
+
+test('should return string format for RGB color', function() {
+  let result = fixColorValue('#2c66f1', 'RGB');;
+
+  expect(result).toEqual('rgb(44, 102, 241)');
+
+});
+
+
+test('should return color object for HEX color', function() {
+  let result = fixColorValue('#2c66f1', 'HEX', true);;
+
+  expect(result).toEqual({ "r": 44, "g": 102, "b": 241});
+
+});
+
+test('should return string format for HEX color', function() {
+  let result = fixColorValue('#2c66f1', 'HEX');;
+
+  expect(result).toEqual('#2c66f1');
+
+});
+
+test('should return color object for HSV color', function() {
+  let result = fixColorValue('#2c66f1', 'HSV', true);;
+
+  expect(result).toEqual({ "h": 222, "s": 0.82, "v": 0.95});
+
+});
+
+test('should return string format for HSV color', function() {
+  let result = fixColorValue('#2c66f1', 'HSV');;
+
+  expect(result).toEqual('hsv(222deg, 82%, 95%)');
+
+});
+
+
+test('should return color object for HSLuv color', function() {
+  let result = fixColorValue('#2c66f1', 'HSLuv', true);;
+
+  expect(result).toEqual({ "l": 260, "u": 91, "v": 47});
+
+});
+
+test('should return string format for HSLuv color', function() {
+  let result = fixColorValue('#2c66f1', 'HSLuv');;
+
+  expect(result).toEqual('hsluv(260, 91, 47)');
+
+});
+
+test('should return color object for LAB color', function() {
+  let result = fixColorValue('#2c66f1', 'LAB', true);;
+
+  expect(result).toEqual({ "l": 46, "a": 22, "b": -77});
+
+});
+
+test('should return string format for LAB color', function() {
+  let result = fixColorValue('#2c66f1', 'LAB');;
+
+  expect(result).toEqual('lab(46%, 22, -77)');
+
+});
+
+test('should return color object for LCH color', function() {
+  let result = fixColorValue('#2c66f1', 'LCH', true);;
+
+  expect(result).toEqual({ "l": 46, "c": 80, "h": 286});
+
+});
+
+test('should return string format for LCH color', function() {
+  let result = fixColorValue('#2c66f1', 'LCH');;
+
+  expect(result).toEqual('lch(46%, 80, 286deg)');
+
+});
+
+
+test('should return color object for CAM02 color', function() {
+  let result = fixColorValue('#2c66f1', 'CAM02', true);;
+
+  expect(result).toEqual({ "J": 48, "a": -7, "b": -35});
+
+});
+
+test('should return string format for CAM02 color', function() {
+  let result = fixColorValue('#2c66f1', 'CAM02');;
+
+  expect(result).toEqual('jab(48%, -7, -35)');
+
+});
+
+test('should return color object for CAM02 (polar) color', function() {
+  let result = fixColorValue('#2c66f1', 'CAM02p', true);;
+
+  expect(result).toEqual({ "J": 35, "C": 75, "h": 258});
+
+});
+
+test('should return string format for CAM02 (polar) color', function() {
+  let result = fixColorValue('#2c66f1', 'CAM02p');;
+
+  expect(result).toEqual('jch(35%, 75, 258deg)');
+
+});

--- a/packages/contrast-colors/test/generateAdaptiveTheme.test.js
+++ b/packages/contrast-colors/test/generateAdaptiveTheme.test.js
@@ -77,6 +77,73 @@ test('should generate theme for three colors', function() {
 
 });
 
+test('should generate theme for three colors in LCH format', function() {
+  let theme = generateAdaptiveTheme({
+    baseScale: "gray",
+    colorScales: [
+      {
+        name: "gray",
+        colorKeys: ['#cacaca', '#323232'],
+        colorspace: 'HSL',
+        ratios: [1, 1.2, 1.4, 2, 3, 4.5, 6, 8, 12, 21]
+      },
+      {
+        name: "blue",
+        colorKeys: ['#0000ff'],
+        colorspace: 'LAB',
+        ratios: [2, 3, 4.5, 8, 12]
+      },
+      {
+        name: "red",
+        colorKeys: ['#ff0000'],
+        colorspace: 'RGB',
+        ratios: [2, 3, 4.5, 8, 12]
+      }
+    ],
+    output: "LCH"});
+    let themeLight = theme(90);;
+
+    expect(themeLight).toEqual([
+      { background: "#e1e1e1" },
+      {
+        name: 'gray',
+        values: [
+          {name: "gray100", contrast: 1, value: "lch(89%, 0, 0deg)"},
+          {name: "gray200", contrast: 1.2, value: "lch(83%, 0, 0deg)"},
+          {name: "gray300", contrast: 1.4, value: "lch(77%, 0, 0deg)"},
+          {name: "gray400", contrast: 2, value: "lch(66%, 0, 0deg)"},
+          {name: "gray500", contrast: 3, value: "lch(54%, 0, 0deg)"},
+          {name: "gray600", contrast: 4.5, value: "lch(42%, 0, 0deg)"},
+          {name: "gray700", contrast: 6, value: "lch(35%, 0, 0deg)"},
+          {name: "gray800", contrast: 8, value: "lch(27%, 0, 0deg)"},
+          {name: "gray900", contrast: 12, value: "lch(14%, 0, 0deg)"},
+          {name: "gray1000", contrast: 21, value: "lch(0%, 0, 0deg)"}
+        ]
+      },
+      {
+        name: 'blue',
+        values: [
+          {name: "blue100", contrast: 2, value: "lch(65%, 62, 302deg)"},
+          {name: "blue200", contrast: 3, value: "lch(53%, 86, 301deg)"},
+          {name: "blue300", contrast: 4.5, value: "lch(41%, 109, 301deg)"},
+          {name: "blue400", contrast: 8, value: "lch(25%, 110, 301deg)"},
+          {name: "blue500", contrast: 12, value: "lch(13%, 57, 301deg)"}
+        ]
+      },
+      {
+        name: 'red',
+        values: [
+          {name: "red100", contrast: 2, value: "lch(66%, 61, 27deg)"},
+          {name: "red200", contrast: 3, value: "lch(55%, 103, 39deg)"},
+          {name: "red300", contrast: 4.5, value: "lch(43%, 90, 41deg)"},
+          {name: "red400", contrast: 8, value: "lch(28%, 65, 39deg)"},
+          {name: "red500", contrast: 12, value: "lch(14%, 42, 33deg)"}
+        ]
+      }
+    ]);
+
+});
+
 test('should generate theme for three colors with negative ratios', function() {
   let theme = generateAdaptiveTheme({
     baseScale: "gray",

--- a/packages/contrast-colors/test/generateContrastColors.test.js
+++ b/packages/contrast-colors/test/generateContrastColors.test.js
@@ -128,6 +128,38 @@ test('should generate slightly lighter & darker oranges on a lighter midtone sla
   expect(colors).toEqual([ '#b84601', '#d76202' ]);
 });
 
+// Output formats 
+test('should generate 2 colors in HEX format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02'});;
+
+  expect(colors).toEqual([ '#5490e0', '#2c66f1' ]);
+});
+test('should generate 2 colors in RGB format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02', output: 'RGB'});;
+
+  expect(colors).toEqual([ 'rgb(84, 144, 224)', 'rgb(44, 102, 241)' ]);
+});
+test('should generate 2 colors in HSL format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02', output: 'HSL'});;
+
+  expect(colors).toEqual([ 'hsl(214deg, 69%, 60%)', 'hsl(222deg, 88%, 56%)' ]);
+});
+test('should generate 2 colors in HSV format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02', output: 'HSV'});;
+
+  expect(colors).toEqual([ 'hsv(214deg, 63%, 88%)', 'hsv(222deg, 82%, 95%)' ]);
+});
+test('should generate 2 colors in LAB format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02', output: 'LAB'});;
+
+  expect(colors).toEqual([ 'lab(58%, -1, -47)', 'lab(46%, 22, -77)' ]);
+});
+test('should generate 2 colors in LCH format', function() {
+  let colors = generateContrastColors({colorKeys: ['#2451FF', '#C9FEFE', '#012676'], base: '#f5f5f5', ratios: [3, 4.5], colorspace: 'CAM02', output: 'LCH'});;
+
+  expect(colors).toEqual([ 'lch(58%, 47, 269deg)', 'lch(46%, 80, 286deg)' ]);
+});
+
 // Expected errors
 test('should generate no colors, missing colorKeys', function() {
   expect(


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
This issue closes #75 

Added `output` option to `generateContrastColors` and `generateAdaptiveTheme` functions.

The **output** option refers to the desired color format that is returned by the function. Currently (and now by default), the output format is `"HEX"`. However, now the following additional formats can be chosen by the user:

| Output option | Sample value |
|---------------|--------------|
| `'HEX'`  _(default)_ | `#RRGGBB` |
| `'RGB'`       | `rgb(255, 255, 255)` |
| `'HSL'`       | `hsl(360deg, 0%, 100%)` |
| `'HSV'`       | `hsv(360deg, 0%, 100%)` |
| `'HSLuv'`     | `hsluv(360, 0, 100)` |
| `'LAB'`       | `lab(100%, 0, 0)` |
| `'LCH'`       | `lch(100%, 0, 360deg)` |
| `'CAM02'`     | `jab(100%, 0, 0)`|
| `'CAM02p'`    | `jch(100%, 0, 360deg)` |

Output formats conform to the [W3C CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/) spec for the supported options (rgb, hex, lab, lch, hsl).

The formatting is performed by the `fixColorValue(color, format, object)` function. 
- `color` is the input color, of any format
- `format` is the desired output of the color
- `object` is a boolean option to either return a **string** or **object**. The object format conforms to d3 module formatting for these colors (sans the opacity object), and the string format conforms to W3C spec as mentioned above.

Within this function, another helper function filters through any `NaN` values that d3 returns for a color and replaces them with 0. While this may not be technically correct in the color science realm, the output and consumption of these colors using a `0` value where a `NaN` is defined is inconsequential. Primary example being the definition of grays in LCh space. While LCh would assign `NaN` to the chroma and hue, a value of `0` would produce the same color, as any value in place of `NaN` would produce the same output when clamped to RGB.

## Motivation
<!-- How do your changes support this project's goals? -->
This enhancement will enable teams that want to manipulate colors beyond Leonardo, or leverage supported color specs more directly. This removes the barrier for users to create their own color transformations as well.

This PR includes thorough testing for the new `fixColorValue()` function.

Additional tests to verify accuracy of output option are included in `generateContrastColors` and `generateAdaptiveTheme` test suites.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
