### PR TITLE
Support to numeric-only hex values in bulk import (#83)

### DIFF
--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -326,6 +326,11 @@ window.cancelBulk = function cancelBulk() {
 window.bulkColorInput = function bulkColorInput() {
   let bulkInputs = document.getElementById('bulkColors');
   let bulkValues = bulkInputs.value.replace(/\r\n/g,"\n").replace(/[,\/]/g,"\n").replace(" ", "").replace(/['\/]/g, "").replace(/["\/]/g, "").split("\n");
+  for (let i=0; i<bulkValues.length; i++) {
+    if (!bulkValues[i].startsWith('#')) {
+      bulkValues[i] = '#' + bulkValues[i]
+    }
+  }
   let isSwatch = document.getElementById('importAsSwatch').checked;
   let bgInput = document.getElementById('bgField_2').value; // input in Dialog
   let bg = document.getElementById('bgField'); // input in UI

--- a/packages/ui/src/theme.js
+++ b/packages/ui/src/theme.js
@@ -978,6 +978,11 @@ window.bulkItemColorInput = function bulkItemColorInput(e) {
 
   let bulkInputs = document.getElementById('bulkColors');
   let bulkValues = bulkInputs.value.replace(/\r\n/g,"\n").replace(/[,\/]/g,"\n").replace(" ", "").replace(/['\/]/g, "").replace(/["\/]/g, "").split("\n");
+  for (let i=0; i<bulkValues.length; i++) {
+    if (!bulkValues[i].startsWith('#')) {
+      bulkValues[i] = '#' + bulkValues[i]
+    }
+  }
   // let isSwatch = document.getElementById('importAsSwatch').checked;
   let bgInput = currentBackgroundColor;
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
Support importing bulk hex values without hash `#` symbol.
This closes #83 


## Motivation
<!-- How do your changes support this project's goals? -->
This will improve the workflow for copying colors from design tools like Sketch or Figma into Leonardo.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
