### PR TITLE
Improve Typescript return types

### DIFF
--- a/packages/contrast-colors/index.d.ts
+++ b/packages/contrast-colors/index.d.ts
@@ -15,20 +15,23 @@ export = ContrastColors;
 
 declare namespace ContrastColors {
   type InterpolationColorspace = 'CAM02' | 'LCH' | 'LAB' | 'HSL' | 'HSLuv' | 'RGB' | 'HSV';
+
   type Colorspace = 'CAM02' | 'CAM02p' | 'LCH' | 'LAB' | 'HSL' | 'HSLuv' | 'RGB' | 'HSV' | 'HEX';
   
   type RGBArray = number[];
-  
-  type AdaptiveTheme = (brightness: number, constrast: number) => AdaptiveTheme | ({ 
-    background: string 
-  } | {
+
+  type AdaptiveThemeBackground = { background: string };
+
+  type AdaptiveThemeColorScheme = {
     name: string,
     values: {
       name: string,
       contrast: number,
       value: string
-    }[]
-  })[];
+    }[];
+  };
+  
+  type AdaptiveTheme = (AdaptiveThemeBackground | AdaptiveThemeColorScheme)[];
 
   interface ColorScale {
     colorKeys: string[],
@@ -99,7 +102,7 @@ declare namespace ContrastColors {
   
   function ratioName(r: number[]): number[] | never;
   
-  function generateAdaptiveTheme({ 
+  function generateAdaptiveTheme<T>({ 
     colorScales, 
     baseScale,
     brightness,
@@ -108,14 +111,14 @@ declare namespace ContrastColors {
   }: {
     colorScales: NamedColorScale[],
     baseScale: string,
-    brightness?: number,
+    brightness?: T,
     contrast?: number,
     output?: Colorspace,
-  }): AdaptiveTheme | never;
+  }): T extends number ? AdaptiveTheme : (brightness: number, constrast?: number) => AdaptiveTheme | never;
   
-  function fixColorValue(
+  function fixColorValue<T extends boolean = false>(
     color: string, 
     format: Colorspace, 
-    object?: boolean
-  ): string | { [key: string]: number };
+    object?: T
+  ): T extends false ? string : { [key: string]: number };
 }


### PR DESCRIPTION


<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
Types returned from 'generateAdaptiveTheme' and 'fixColorValue' now are variable depending on a generic parameter.
eg.
```typescript
// color will be of type 'string',
// while before it would have been of type 'string | { [key: string]: number }'
const color = fixColorValue('#2c66f1', 'HSL', false)
```
This closes #99 

## Motivation
<!-- How do your changes support this project's goals? -->
This helps the user to better understand what the function will return.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
