### PR TITLE
added output format Theme.contrastColorPairs

### DIFF
--- a/packages/contrast-colors/README.md
+++ b/packages/contrast-colors/README.md
@@ -191,13 +191,13 @@ There are two types of output you can get from the `Theme` class:
 | Getter | Description of output |
 |--------|-----------------------|
 | `Theme.contrastColors` | Returns array of color objects with key-value pairs |
+| `Theme.contrastColorPairs` | Returns object with key-value pairs |
 | `Theme.contrastColorValues` | Returns flat array of color values |
 
 
-### `.contrastColors` output
-Each color instance is named by concatenating the user-defined color name with a numeric value (eg `name: 'gray'`; `gray100`).
+### `Theme.contrastColors`
+Each color is an object named by user-defined value (eg `name: 'gray'`). "Values" array consists of all generated color values for the color, with properties `name`, `contrast`, and `value`:
 
-Example output:
 ```js
 [
   { background: "#e0e0e0" },
@@ -222,10 +222,25 @@ Example output:
 ]
 ```
 
-### `.contrastColorValues` output
-For the same example theme shown above, these values would be returned in a flat array when calling `Theme.contrastColorValues`.
+### `Theme.contrastColorPairs`
+Simplified format as an object of key-value pairs. Property is equal to the [generated](#Ratios-as-an-array) or [user-defined name](#Ratios-as-an-object) for each generated value.
 
-Example output:
+```js
+{
+  "gray100": "#e0e0e0";
+  "gray200": "#a0a0a0";
+  "gray300": "#808080";
+  "gray400": "#646464";
+  "blue100": "#b18cff";
+  "blue200": "#8d63ff";
+  "blue300": "#623aff";
+  "blue400": "#1c0ad1";
+}
+```
+
+### `Theme..contrastColorValues`
+Returns all color values in a flat array.
+
 ```js
 [
   "#e0e0e0",

--- a/packages/contrast-colors/test/theme.test.js
+++ b/packages/contrast-colors/test/theme.test.js
@@ -58,6 +58,38 @@ test('should generate theme for three colors', () => {
   ]);
 });
 
+
+test('should output theme as key-value pairs', () => {
+  const gray = new BackgroundColor({ name: 'gray', colorKeys: ['#cacaca', '#323232'], colorspace: 'HSL', ratios: [1, 1.2, 1.4, 2, 3, 4.5, 6, 8, 12, 21] });
+  const blue = new Color({ name: 'blue', colorKeys: ['#0000ff'], colorspace: 'LAB', ratios: [2, 3, 4.5, 8, 12] });
+  const red = new Color({ name: 'red', colorKeys: ['#ff0000'], colorspace: 'RGB', ratios: [2, 3, 4.5, 8, 12] });
+  const theme = new Theme({ colors: [gray, blue, red], backgroundColor: gray, lightness: 90 });
+  const themeColors = theme.contrastColorPairs;
+
+  expect(themeColors).toEqual({
+    gray100:'#e0e0e0',
+    gray200: '#cecece',
+    gray300: '#bfbfbf',
+    gray400:'#a0a0a0',
+    gray500:'#808080',
+    gray600: '#646464',
+    gray700:'#515151',
+    gray800:'#404040',
+    gray900: '#232323',
+    gray1000: '#000000',
+    blue100: '#b28bff',
+    blue200: '#8f62ff',
+    blue300: '#6339ff',
+    blue400: '#1e0bcf',
+    blue500: '#221165',
+    red100: '#ff7474',
+    red200: '#ff1010',
+    red300: '#cc0000',
+    red400:'#850000',
+    red500: '#4f0000',
+  });
+});
+
 test('should generate theme for three colors in LCH format', () => {
   const gray = new BackgroundColor({ name: 'gray', colorKeys: ['#cacaca', '#323232'], colorspace: 'HSL', ratios: [1, 1.2, 1.4, 2, 3, 4.5, 6, 8, 12, 21] });
   const blue = new Color({ name: 'blue', colorKeys: ['#0000ff'], colorspace: 'LAB', ratios: [2, 3, 4.5, 8, 12] });

--- a/packages/contrast-colors/test/theme.test.js
+++ b/packages/contrast-colors/test/theme.test.js
@@ -67,6 +67,7 @@ test('should output theme as key-value pairs', () => {
   const themeColors = theme.contrastColorPairs;
 
   expect(themeColors).toEqual({
+    background: '#e1e1e1',
     gray100:'#e0e0e0',
     gray200: '#cecece',
     gray300: '#bfbfbf',
@@ -449,6 +450,62 @@ test('should generate colors with user-defined names', () => {
       ],
     },
   ]);
+});
+
+
+test('should generate colors with user-defined names as key-value pairs', () => {
+  const grayRatios = {
+    GRAY_1: -1.8,
+    GRAY_2: -1.2,
+    GRAY_3: 1,
+    GRAY_4: 1.2,
+    GRAY_5: 1.4,
+    GRAY_6: 2,
+    GRAY_7: 3,
+    GRAY_8: 4.5,
+    GRAY_9: 21,
+  };
+  const blueRatios = {
+    BLUE_LARGE_TEXT: 3,
+    BLUE_TEXT: 4.5,
+    BLUE_HIGH_CONTRAST: 8,
+    BLUE_HIGHEST_CONTRAST: 12,
+  };
+  const redRatios = {
+    'red--largeText': 3,
+    'red--text': 4.5,
+    'red--highContrast': 8,
+    'red--highestContrast': 12,
+  };
+
+  const gray = new BackgroundColor({ name: 'gray', colorKeys: ['#cacaca'], colorspace: 'HSL', ratios: grayRatios });
+  const blue = new Color({ name: 'blue', colorKeys: ['#0000ff'], colorspace: 'LAB', ratios: blueRatios });
+  const red = new Color({ name: 'red', colorKeys: ['#ff0000'], colorspace: 'RGB', ratios: redRatios });
+  const theme = new Theme({ colors: [gray, blue, red], backgroundColor: gray, lightness: 20 });
+  const themeColors = theme.contrastColorPairs;
+
+  expect(themeColors).toEqual(
+    { 
+      background: '#303030', 
+      'GRAY_1': '#000000' ,
+      'GRAY_2': '#222222' ,
+      'GRAY_3': '#313131' ,
+      'GRAY_4': '#3c3c3c' ,
+      'GRAY_5': '#464646' ,
+      'GRAY_6': '#5d5d5d' ,
+      'GRAY_7': '#787878' ,
+      'GRAY_8': '#969696' ,
+      'GRAY_9': '#ffffff' ,
+      'BLUE_LARGE_TEXT': '#8457ff' ,
+      'BLUE_TEXT': '#a97fff' ,
+      'BLUE_HIGH_CONTRAST': '#d8beff' ,
+      'BLUE_HIGHEST_CONTRAST': '#f7f2ff' ,
+      'red--largeText': '#f20000' ,
+      'red--text': '#ff6262' ,
+      'red--highContrast': '#ffb7b7' ,
+      'red--highestContrast': '#fff1f1' 
+    }
+  );
 });
 
 test('should generate colors with user-defined names and increased contrast', () => {

--- a/packages/contrast-colors/theme.js
+++ b/packages/contrast-colors/theme.js
@@ -152,12 +152,12 @@ class Theme {
   _findContrastColors() {
     const bgRgbArray = chroma(String(this._backgroundColorValue)).rgb();
     const baseV = this._lightness / 100;
-
-    const baseObj = { background: convertColorValue(this._backgroundColorValue, this._output) };
+    const convertedBackgroundColorValue = convertColorValue(this._backgroundColorValue, this._output);
+    const baseObj = { background: convertedBackgroundColorValue };
 
     const returnColors = []; // Array to be populated with JSON objects for each color, including names & contrast values
     const returnColorValues = []; // Array to be populated with flat list of all color values
-    const returnColorPairs = {}; // Objext to be populated with flat list of all color values as named key-value pairs
+    const returnColorPairs = {...baseObj}; // Objext to be populated with flat list of all color values as named key-value pairs
     returnColors.push(baseObj);
 
     this._modifiedColors.map((color) => {

--- a/packages/contrast-colors/theme.js
+++ b/packages/contrast-colors/theme.js
@@ -51,6 +51,7 @@ class Theme {
     // this._setContrasts(this._contrast);
 
     this._findContrastColors();
+    this._findContrastColorPairs();
     this._findContrastColorValues();
   }
 
@@ -115,6 +116,10 @@ class Theme {
     return this._contrastColors;
   }
 
+  get contrastColorPairs() {
+    return this._contrastColorPairs;
+  }
+
   get contrastColorValues() {
     return this._contrastColorValues;
   }
@@ -152,6 +157,7 @@ class Theme {
 
     const returnColors = []; // Array to be populated with JSON objects for each color, including names & contrast values
     const returnColorValues = []; // Array to be populated with flat list of all color values
+    const returnColorPairs = {}; // Objext to be populated with flat list of all color values as named key-value pairs
     returnColors.push(baseObj);
 
     this._modifiedColors.map((color) => {
@@ -192,6 +198,8 @@ class Theme {
             value: contrastColors[i],
           };
           newArr.push(obj);
+          // Push the same values to the returnColorPairs object
+          returnColorPairs[n] = contrastColors[i];
           // Push the same value to the returnColorValues array
           returnColorValues.push(contrastColors[i]);
         }
@@ -200,8 +208,13 @@ class Theme {
       return null;
     });
     this._contrastColorValues = returnColorValues;
+    this._contrastColorPairs = returnColorPairs;
     this._contrastColors = returnColors;
     return this._contrastColors;
+  }
+
+  _findContrastColorPairs() {
+    return this._contrastColorPairs;
   }
 
   _findContrastColorValues() {


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
This PR closes #131 

Adds `Theme.contrastColorPairs` as a getter to return contrast color output in simplified format:
```js
{
    background: '#e1e1e1',
    gray100:'#e0e0e0',
    gray200: '#cecece',
    gray300: '#bfbfbf',
    blue100: '#b28bff',
    blue200: '#8f62ff',
    blue300: '#6339ff',
    red100: '#ff7474',
    red200: '#ff1010',
    red300: '#cc0000'
  }
```
This PR includes two additional test to verify this output format; one for generated color names and another with user-defined color names.

## Motivation
<!-- How do your changes support this project's goals? -->
Flexibility of output formats in Leonardo to aid in transformation process of data when using color output as variables, such as CSS Properties (eg, `--gray300: '#bfbfbf'`

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
