### PR TITLE
added polar CAM02 interpolation option in UI

### DIFF
--- a/packages/ui/src/charts.js
+++ b/packages/ui/src/charts.js
@@ -243,12 +243,22 @@ function init3dChart(){
 
   let pi = Math.PI;
 
-  if (spaceOpt == 'CAM02') {
+  if (spaceOpt === 'CAM02') {
     for(let i=0; i<CAMArrayA.length; i++) {
       colorPlot.push({x: CAMArrayA[i]/10, y: CAMArrayJ[i]/10 * -1, z: CAMArrayB[i]/10, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'LCH') {
+  if (spaceOpt === 'CAM02p') {
+    for(let i=0; i<JCHArrayC.length; i++) {
+      let angle = JCHArrayH[i] * (pi/180);
+      let r = JCHArrayC[i];
+      // Polar:
+      colorPlot.push({x: (r * Math.cos(angle))/13, y: JCHArrayJ[i]/13 * -1, z: (r * Math.sin(angle))/13, id: 'point_' + cnt++});
+      // Cartesian:
+      // colorPlot.push({x: JCHArrayH[i]/(Math.PI * 10), y: JCHArrayJ[i]/10 * -1, z: JCHArrayC[i]/10, id: 'point_' + cnt++});
+    }
+  }
+  if (spaceOpt === 'LCH') {
     for(let i=0; i<LCHArrayC.length; i++) {
       let angle = LCHArrayH[i] * (pi/180);
       let r = LCHArrayC[i];
@@ -258,12 +268,12 @@ function init3dChart(){
       // colorPlot.push({x: LCHArrayH[i]/(Math.PI * 10), y: LCHArrayL[i]/10 * -1, z: LCHArrayC[i]/10, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'LAB') {
+  if (spaceOpt === 'LAB') {
     for(let i=0; i<LABArrayA.length; i++) {
       colorPlot.push({x: LABArrayA[i]/13, y: LABArrayL[i]/13 * -1, z: LABArrayB[i]/13, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'HSL') {
+  if (spaceOpt === 'HSL') {
     for(let i=0; i<HSLArrayL.length; i++) {
       let angle = HSLArrayH[i] * (pi/180);
       let r = HSLArrayS[i];
@@ -273,7 +283,7 @@ function init3dChart(){
       // colorPlot.push({x: HSLArrayH[i]/(10*pi) - 7, y: HSLArrayL[i]*10 * -1, z: HSLArrayS[i]*10 - 7, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'HSLuv') {
+  if (spaceOpt === 'HSLuv') {
     for(let i=0; i<HSLuvArrayL.length; i++) {
       let angle = HSLuvArrayL[i] * (pi/180);
       let r = HSLuvArrayU[i];
@@ -283,7 +293,7 @@ function init3dChart(){
       // colorPlot.push({x: HSLuvArrayL[i]/(10*pi) - 7, y: HSLuvArrayV[i]/10 * -1, z: HSLuvArrayU[i]/10 -10, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'HSV') {
+  if (spaceOpt === 'HSV') {
     for(let i=0; i<HSVArrayL.length; i++) {
       let angle = HSVArrayH[i] * (pi/180);
       let r = HSVArrayS[i];
@@ -293,7 +303,7 @@ function init3dChart(){
       // colorPlot.push({x: HSVArrayH[i]/(10*pi) - 7, y: HSVArrayL[i]*10 * -1, z: HSVArrayS[i]*10 -7, id: 'point_' + cnt++});
     }
   }
-  if (spaceOpt == 'RGB') {
+  if (spaceOpt === 'RGB') {
     for(let i=0; i<RGBArrayR.length; i++) {
       colorPlot.push({x: RGBArrayR[i]/30 - 5, y: RGBArrayG[i]/30 * -1, z: RGBArrayB[i]/30 - 5, id: 'point_' + cnt++});
     }
@@ -508,6 +518,14 @@ function createAllCharts(mode) {
     createChart(lchDataH, 'Hue', 'Lightness', "#chart2", 0, 360);
     createChartHeader('Chroma / Hue', 'chart3');
     createChart(lchDataCH, 'Chroma', 'Hue', "#chart3", 0, 100);
+  }
+  if (mode=="CAM02p") {
+    createChartHeader('Chroma / Lightness', 'chart1');
+    createChart(jchDataC, 'Chroma', 'Lightness', "#chart1", 0, 100);
+    createChartHeader('Hue / Lightness', 'chart2');
+    createChart(jchDataH, 'Hue', 'Lightness', "#chart2", 0, 360);
+    createChartHeader('Chroma / Hue', 'chart3');
+    createChart(jchDataCH, 'Chroma', 'Hue', "#chart3", 0, 100);
   }
   if (mode=="LAB") {
     createChartHeader('Green Red / Lightness', 'chart1');

--- a/packages/ui/src/converter.html
+++ b/packages/ui/src/converter.html
@@ -71,6 +71,7 @@
             <div class="spectrum-Dropdown">
               <select class="spectrum-FieldButton spectrum-Dropdown-trigger" name="type" id="type">
                 <option>CAM02</option>
+                <option>CAM02p</option>
                 <option>Lch</option>
                 <option>Lab</option>
                 <option>HSL</option>

--- a/packages/ui/src/converter.js
+++ b/packages/ui/src/converter.js
@@ -83,6 +83,11 @@ function convert(c, typeId = type.value) {
       B = d3.jab(c).a;
       C = d3.jab(c).b;
     }
+    if(typeId == 'CAM02p') {
+      A = d3.jch(c).J;
+      B = d3.jch(c).C;
+      C = d3.jch(c).h;
+    }
     if(typeId == 'Lab') {
       A = d3.lab(c).l;
       B = d3.lab(c).a;
@@ -133,6 +138,11 @@ function returnColor() {
     valArr = valNums.split(','); // split numbers into array
     val = d3.jab(Number(valArr[0]), Number(valArr[1]), Number(valArr[2])).formatHsl();
   }
+  if(val.match(/^jch\(/)) {
+    valNums = val.match(/\(.*?\)/g).toString().replace("(", "").replace(")", "").trim(); // find numbers only
+    valArr = valNums.split(','); // split numbers into array
+    val = d3.jch(Number(valArr[0]), Number(valArr[1]), Number(valArr[2])).formatHsl();
+  }
   if(val.match(/^hsluv\(/)) {
     valNums = val.match(/\(.*?\)/g).toString().replace("(", "").replace(")", "").trim(); // find numbers only
     valArr = valNums.split(','); // split numbers into array
@@ -150,6 +160,7 @@ function returnColor() {
   if(typeId == 'HSL') { typeArr = ['H', 'S', 'L']; }
   if(typeId == 'HSLuv') { typeArr = ['H (l)', 'S (u)', 'L (v)']; }
   if(typeId == 'CAM02') { typeArr = ['J', 'a', 'b']; typeId = 'jab';}
+  if(typeId == 'CAM02p') { typeArr = ['J', 'c', 'h']; typeId = 'jch';}
   if(typeId == 'Lab') { typeArr = ['L', 'a', 'b']; }
   if(typeId == 'Lch') { typeArr = ['L', 'c', 'h']; }
   if(typeId == 'RGB') { typeArr = ['R', 'G', 'B']; }

--- a/packages/ui/src/data.js
+++ b/packages/ui/src/data.js
@@ -17,6 +17,9 @@ function createData(colors) {
   let CAM_J = [];
   let CAM_A = [];
   let CAM_B = [];
+  let JCH_J = [];
+  let JCH_C = [];
+  let JCH_H = [];
   let LAB_L = [];
   let LAB_A = [];
   let LAB_B = [];
@@ -40,6 +43,9 @@ function createData(colors) {
     CAM_J.push(d3.jab(colors[i]).J);
     CAM_A.push(d3.jab(colors[i]).a);
     CAM_B.push(d3.jab(colors[i]).b);
+    JCH_J.push(d3.jch(colors[i]).J);
+    JCH_C.push(d3.jch(colors[i]).C);
+    JCH_H.push(d3.jch(colors[i]).h);
     LAB_L.push(d3.lab(colors[i]).l);
     LAB_A.push(d3.lab(colors[i]).a);
     LAB_B.push(d3.lab(colors[i]).b);
@@ -64,6 +70,9 @@ function createData(colors) {
   CAM_J = CAM_J.filter(function(value) {return !Number.isNaN(value);});
   CAM_A = CAM_A.filter(function(value) {return !Number.isNaN(value);});
   CAM_B = CAM_B.filter(function(value) {return !Number.isNaN(value);});
+  JCH_J = JCH_J.filter(function(value) {return !Number.isNaN(value);});
+  JCH_C = JCH_C.filter(function(value) {return !Number.isNaN(value);});
+  JCH_H = JCH_H.filter(function(value) {return !Number.isNaN(value);});
   LAB_L = LAB_L.filter(function(value) {return !Number.isNaN(value);});
   LAB_A = LAB_A.filter(function(value) {return !Number.isNaN(value);});
   LAB_B = LAB_B.filter(function(value) {return !Number.isNaN(value);});
@@ -86,6 +95,9 @@ function createData(colors) {
   window.CAMArrayJ = [];
   window.CAMArrayA = [];
   window.CAMArrayB = [];
+  window.JCHArrayJ = [];
+  window.JCHArrayC = [];
+  window.JCHArrayH = [];
   window.LABArrayL = [];
   window.LABArrayA = [];
   window.LABArrayB = [];
@@ -108,6 +120,9 @@ function createData(colors) {
   window.CAMArrayJmin = [];
   window.CAMArrayAmin = [];
   window.CAMArrayBmin = [];
+  window.JCHArrayJmin = [];
+  window.JCHArrayCmin = [];
+  window.JCHArrayHmin = [];
   window.LABArrayLmin = [];
   window.LABArrayAmin = [];
   window.LABArrayBmin = [];
@@ -139,6 +154,15 @@ function createData(colors) {
   }
   for (let i = 0; i < CAM_B.length; i=i+delta) {
     CAMArrayB.push(CAM_B[i]);
+  }
+  for (let i = 0; i < JCH_J.length; i=i+delta) {
+    JCHArrayJ.push(JCH_J[i]);
+  }
+  for (let i = 0; i < JCH_C.length; i=i+delta) {
+    JCHArrayC.push(JCH_C[i]);
+  }
+  for (let i = 0; i < JCH_H.length; i=i+delta) {
+    JCHArrayH.push(JCH_H[i]);
   }
   for (let i = 0; i < LAB_L.length; i=i+delta) {
     LABArrayL.push(LAB_L[i]);
@@ -208,6 +232,17 @@ function createData(colors) {
   for (let i = 0; i < CAM_B.length; i=i+deltamin) {
     CAMArrayBmin.push(CAM_B[i]);
   }
+
+  for (let i = 0; i < JCH_J.length; i=i+deltamin) {
+    JCHArrayJmin.push(JCH_J[i]);
+  }
+  for (let i = 0; i < JCH_C.length; i=i+deltamin) {
+    JCHArrayCmin.push(JCH_C[i]);
+  }
+  for (let i = 0; i < JCH_H.length; i=i+deltamin) {
+    JCHArrayHmin.push(JCH_H[i]);
+  }
+
   for (let i = 0; i < LAB_L.length; i=i+deltamin) {
     LABArrayLmin.push(LAB_L[i]);
   }
@@ -296,6 +331,25 @@ function createData(colors) {
     {
       x: CAMArrayAmin,
       y: CAMArrayBmin
+    }
+  ];
+  
+  window.jchDataC = [
+    {
+      x: JCHArrayJmin,
+      y: JCHArrayCmin
+    }
+  ];
+  window.jchDataH = [
+    {
+      x: JCHArrayJmin,
+      y: JCHArrayHmin
+    }
+  ];
+  window.jchDataCH = [
+    {
+      x: JCHArrayHmin,
+      y: JCHArrayCmin
     }
   ];
 

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -525,6 +525,7 @@ function colorspaceOptions() {
 
   var opts = {
     'CAM02': 'CIECAM02',
+    'CAM02p': 'CAM02 (polar)',
     'LCH': 'Lch',
     'LAB': 'Lab',
     'HSL': 'HSL',
@@ -534,6 +535,7 @@ function colorspaceOptions() {
   };
   var opts2 = {
     'CAM02': 'CIECAM02 (recommended)',
+    'CAM02p': 'CIECAM02 (polar)',
     'LCH': 'Lch',
     'LAB': 'Lab',
     'HSL': 'HSL',

--- a/packages/ui/src/theme.js
+++ b/packages/ui/src/theme.js
@@ -350,6 +350,7 @@ function addColorScale(c, k, s, r) {
 
   let opts = {
     'CAM02': 'CIECAM02',
+    'CAM02p': 'CAM02 (polar)',
     'LCH': 'Lch',
     'LAB': 'Lab',
     'HSL': 'HSL',


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
CIECAM02 polar (JCH) option is available for interpolation within `@adobe/leonardo-contrast-colors` (as CAM02p) but was not represented within the UI as an option.

This PR adds the option of CIECAM02 (polar) for interpolation, charts, and modeling.

## Motivation
<!-- How do your changes support this project's goals? -->
Show all the options available in the tool

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/13972198/131891157-a897e0aa-d127-46e7-999a-5048c7b160d2.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
