### PR TITLE
Bugfix apca

### DIFF
--- a/packages/contrast-colors/test/contrast.test.mjs
+++ b/packages/contrast-colors/test/contrast.test.mjs
@@ -41,3 +41,44 @@ test('should provide contrast when passing base value (5.64...)', () => {
 
   expect(contrastValue).toBe(5.635834988986869);
 });
+
+
+/** 
+ * Test APCA colors
+ */
+
+test('should provide APCA contrast of ~ 75.6', () => {
+  const contrastValue = contrast([18, 52, 176], [233, 228, 208], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(75.57062523197818);
+});
+
+test('should provide APCA contrast of ~ -78.3', () => {
+  const contrastValue = contrast([233, 228, 208], [18, 52, 176], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(-78.28508284557655);
+});
+
+test('should provide APCA contrast of ~ 38.7', () => {
+  const contrastValue = contrast([255, 162, 0], [255,255,255], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(38.67214116963013);
+});
+
+test('should provide APCA contrast of ~ -43.1', () => {
+  const contrastValue = contrast([255,255,255], [255, 162, 0], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(-43.12544505836451);
+});
+
+test('should provide APCA contrast of ~ -107.9', () => {
+  const contrastValue = contrast([255,255,255], [0, 0, 0], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(-107.88473318309848);
+});
+
+test('should provide APCA contrast of ~ 106', () => {
+  const contrastValue = contrast([0, 0, 0], [255,255,255], undefined, 'wcag3'); // lighter gray is UI color, gray is base. Should return negative whole number
+
+  expect(contrastValue).toBe(106.04067321268862);
+});

--- a/packages/contrast-colors/utils.mjs
+++ b/packages/contrast-colors/utils.mjs
@@ -385,12 +385,12 @@ function luminance(r, g, b) {
 }
 
 function getContrast(color, base, baseV, method='wcag2') {
+  if (baseV === undefined) { // If base is an array and baseV undefined
+    const baseLightness = chroma.rgb(...base).hsluv()[2];
+    baseV = round(baseLightness / 100, 2);
+  }
+
   if(method === 'wcag2') {
-    if (baseV === undefined) { // If base is an array and baseV undefined
-      const baseLightness = chroma.rgb(...base).hsluv()[2];
-      baseV = round(baseLightness / 100, 2);
-    }
-  
     const colorLum = luminance(color[0], color[1], color[2]);
     const baseLum = luminance(base[0], base[1], base[2]);
   
@@ -416,7 +416,7 @@ function getContrast(color, base, baseV, method='wcag2') {
     }
     return -cr1;
   } else if (method === 'wcag3') {
-    return APCAcontrast( sRGBtoY( color ), sRGBtoY( base ) );
+    return (baseV < 0.5) ? APCAcontrast( sRGBtoY( color ), sRGBtoY( base ) ) * -1 : APCAcontrast( sRGBtoY( color ), sRGBtoY( base ) );
   } else {
     throw new Error(`Contrast calculation method ${method} unsupported; use 'wcag2' or 'wcag3'`);
   }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
- Reverses polarity of APCA in `searchColors` function
- Removes notion of polarity in Leonardo for simplification of use. Ie, targeting a contrast of 75 should always be "75" in Leonardo, regardless of whether it's `75` or `-75` in actual APCA calculations.

Why alter polarity?
Leonardo already has a notion of polarity within the context of themes. Negative values mean contrast goes darker in dark themes and lighter in light themes. Introducing APCA's polarity into the mix would convolute the existing model in Leonardo. 

This update does not affect the actual polarity calculations in APCA, as text and background are still appropriately passed to APCA formula.

## Motivation
<!-- How do your changes support this project's goals? -->


## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
