### PR TITLE
Set saturation on instantiation

### DIFF
--- a/packages/contrast-colors/test/themeSetters.test.mjs
+++ b/packages/contrast-colors/test/themeSetters.test.mjs
@@ -64,6 +64,13 @@ test('should set theme output to LCH', () => {
 // Saturation
 test('should set theme saturation to 60%', () => {
   const color = new Color({ name: 'Color', colorKeys: ['#2451FF', '#C9FEFE', '#012676'], ratios: [3, 4.5], colorspace: 'CAM02' });
+  const theme = new Theme({ colors: [color], backgroundColor: '#f5f5f5', output: 'RGB', saturation: 60  });
+  const themeColors = theme.contrastColorValues;
+
+  expect(themeColors).toEqual(['rgb(119, 142, 193)', 'rgb(90, 107, 187)']);
+});
+test('should set theme saturation to 60%', () => {
+  const color = new Color({ name: 'Color', colorKeys: ['#2451FF', '#C9FEFE', '#012676'], ratios: [3, 4.5], colorspace: 'CAM02' });
   const theme = new Theme({ colors: [color], backgroundColor: '#f5f5f5', output: 'RGB'  });
   theme.saturation = 60;
   const themeColors = theme.contrastColorValues;

--- a/packages/contrast-colors/theme.mjs
+++ b/packages/contrast-colors/theme.mjs
@@ -41,6 +41,9 @@ class Theme {
       throw new Error(`Output “${output}” not supported`);
     }
 
+    // Only run the update if saturation is set below 100%
+    if(this._saturation < 100) this._updateColorSaturation(this._saturation);
+
     this._findContrastColors();
     this._findContrastColorPairs();
     this._findContrastColorValues();


### PR DESCRIPTION

<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->
- Added function to initiate theme with proper saturation if instantiated with less than 100% saturation
- Added test to verify proper saturation adjustment if theme initiated with less than 100% saturation

## Motivation
<!-- How do your changes support this project's goals? -->
Should have happened this way in the first place. Otherwise saturation must be explicitly set after the class instantiation.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
