### PR TITLE
Bulk contrast feature in conversion dialog

### DIFF
--- a/packages/ui/src/views/dialog_bulkColorConverter.html
+++ b/packages/ui/src/views/dialog_bulkColorConverter.html
@@ -161,6 +161,45 @@
           </div>
         </div>
       </div>
+
+      <div class="spectrum-Form spectrum-Form--labelsAbove">
+        <div class="spectrum-Form-item">
+          <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel" for="spectrum-textinput-instance">Contrast</label>
+          <div class="spectrum-Form-itemField">
+            <div class="spectrum-FieldGroup">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input convertBulkColorspace" id="checkboxConvert-wcag2">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">Relative luminance</span>
+              </label>
+            </div>
+          </div>
+          <div class="spectrum-Form-itemField">
+            <div class="spectrum-FieldGroup">
+              <label class="spectrum-Checkbox spectrum-Checkbox--sizeM spectrum-FieldGroup-item">
+                <input type="checkbox" class="spectrum-Checkbox-input convertBulkColorspace" id="checkboxConvert-wcag3">
+                <span class="spectrum-Checkbox-box">
+                  <svg class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Checkbox-checkmark" focusable="false" aria-hidden="true">
+                    <use xlink:href="#spectrum-css-icon-Checkmark100" />
+                  </svg>
+                </span>
+                <span class="spectrum-Checkbox-label">APCA</span>
+              </label>
+            </div>
+          </div>
+          <div class="spectrum-Form-itemField">
+            <div class="spectrum-Form-item spectrum-Form-item--row">
+              <label class="spectrum-FieldLabel spectrum-FieldLabel--left spectrum-Fieldlabel--sizeM ">Background color</label>
+              <input type="color" id="bulkConvertBackground" class="keyColor-Item keyColor-Item--standalone"/>
+            </div>
+          </div>
+        </div>
+
+      </div>
     </section>
     <div class="spectrum-ButtonGroup spectrum-Dialog-buttonGroup spectrum-Dialog-buttonGroup--noFooter">
       <button class="spectrum-Button spectrum-Button--sizeM spectrum-Button--secondary spectrum-ButtonGroup-item" onclick="cancelBulkConvert()">Cancel</button>


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
- Adds options to do a bulk contrast evaluation of colors in the "Bulk convert" dialog 
- Provides options for WCAG2 (relative luminance) and WCAG3 (APCA) contrast
- Includes color picker to define a background color to compare against for calculation

## Motivation
When evaluating many colors in a palette, it's nice to be able to see the contrast ratios for every color against a variety of backgrounds. This bulk action saves a lot of time, and is typically performed when doing other conversions for color analysis.

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->
![image](https://user-images.githubusercontent.com/13972198/202580023-ae3fe2d3-eb6a-4971-a3d7-493a3c180e50.png)

Example of output CSV file for both contrast evaluations:
![image](https://user-images.githubusercontent.com/13972198/202580094-2e24dda1-a221-4a35-b177-50c6c50fff6f.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
