### PR TITLE
Update broken typescript definitions for `leonardo-color-contrast`

### DIFF
--- a/packages/contrast-colors/index.d.ts
+++ b/packages/contrast-colors/index.d.ts
@@ -85,7 +85,6 @@ export function contrast(color: RGBArray, base: RGBArray, baseV?: number,
 
 interface ContrastColor extends Color { background: ReturnType<typeof convertColorValue> }
 
-
 interface UpdateColorOptions extends Partial<ColorBase> {
   /**
    * The current name of the color to be updated.

--- a/packages/contrast-colors/index.d.ts
+++ b/packages/contrast-colors/index.d.ts
@@ -21,7 +21,7 @@ interface ColorBase {
   /**
    * Colors to be validated by {@link ChromaJs.valid}
    */
-  colorKeys: any[]
+  colorKeys: any[] // FIXME
   colorspace?: Colorspace
   ratios: Ratios
   smooth?: boolean
@@ -131,7 +131,7 @@ export class Theme implements Required<ThemeBase> {
   readonly contrastColorPairs: ContrastColor
 
   /*  Array to be populated with flat list of all color values */
-  readonly contrastColorValues: any[]
+  readonly contrastColorValues: any[] // FIXME
 
   /** Add individual new colors */
   set addColor(arg: Color)

--- a/packages/contrast-colors/package.json
+++ b/packages/contrast-colors/package.json
@@ -5,6 +5,7 @@
   "repository": "git@github.com:adobe/leonardo.git",
   "main": "./index.js",
   "type": "module",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "default": "./index.js"


### PR DESCRIPTION
WIP to resolve #143 :) There's some typings that I found difficult to infer from usage (currently marked with a `FIXME` comment). I've also exposed a few pre-existing comments as TSDoc annotations.

## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] Test typings
- [ ] Integrate documentation from README as TSDoc annotations?
- [ ] This pull request is ready to merge.
