### PR TITLE
chore: update moon config to use Node v20.11

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -10,7 +10,7 @@ $schema: 'https://moonrepo.dev/schemas/toolchain.json'
 node:
   # The version to use. Must be a semantic version that includes major, minor, and patch.
   # We suggest using the latest active LTS version: https://nodejs.org/en/about/releases
-  version: '20.0.0'
+  version: '20.11'
 
   # The package manager to use when managing dependencies.
   # Accepts "npm" (default), "pnpm", or "yarn".

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.1"
   },
+  "packageManager": "pnpm@8.15.4",
   "engines": {
-    "node": "20.0.0"
-  },
-  "packageManager": "pnpm@8.15.4"
+    "node": "~20.11"
+  }
 }


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->

Leonardo should use latest NodeJS LTS version, setup with moon.

Moon can use partial and alias versions in the toolchain: 
https://moonrepo.dev/docs/concepts/toolchain#version-specification

1. Set node version in moon/toolchain.yml to a partial node version, like '20.11'
2. Run `moon sync projects` to apply the node version to the projects.


Note: Setting the node version in the toolchain.yml to a lts alias, like 'lts/iron' will still give a warning about the version not matching, e.g.

```
➜  leonardo git:(karstens/fix--set-node-version-to-lts) ✗ pnpm moon sync projects
 WARN  Unsupported engine: wanted: {"node":"lts/iron"} (current: {"node":"v20.11.1","pnpm":"8.15.3"})
```

## Motivation
<!-- How do your changes support this project's goals? -->


## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
