### PR TITLE
fix: parse saturation param from theme URL config

### DIFF
--- a/docs/ui/src/js/params.js
+++ b/docs/ui/src/js/params.js
@@ -114,6 +114,19 @@ function paramSetup() {
     contrastSliderVal.innerHTML = `${round(contrast * 100)}%`;
     _theme.contrast = contrast;
 
+    // handle saturation parameter
+    let saturation;
+    if (!config.saturation && config.saturation !== 0) {
+      saturation = 100;
+    } else {
+      saturation = config.saturation;
+    }
+    let saturationSlider = document.getElementById('themeSaturationSlider');
+    let saturationSliderVal = document.getElementById('themeSaturationValue');
+    saturationSlider.value = saturation;
+    saturationSliderVal.innerHTML = `${round(saturation)}%`;
+    _theme.saturation = saturation;
+
     // generate the options for the base scale,
     // then select the option defined in parameters
     baseScaleOptions();


### PR DESCRIPTION
## Description

This PR fixes a bug where the `saturation` parameter in theme URL configs is ignored, causing themes to always load with 100% saturation regardless of the URL parameter value.

## Problem
When users share Leonardo theme URLs with a specific `saturation` value in the config (e.g., `"saturation": 20`), the web UI ignores this parameter and defaults to 100% saturation. This breaks the ability to share complete theme configurations via URL.

## Fix
Added saturation parameter parsing that:
1. Reads `config.saturation` from the URL parameter
2. Defaults to 100 if not specified (maintaining backward compatibility)
3. Updates the saturation slider UI element
4. Updates the saturation display label
5. Sets `_theme.saturation` property

The implementation follows the exact same pattern used for the existing `contrast` parameter (lines 112-116), ensuring consistency with the codebase. The fix is minimal and improves theme sharing.

- [ x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ x] This pull request is ready to merge.
