### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/ui/CHANGELOG.md
+++ b/docs/ui/CHANGELOG.md
@@ -32,7 +32,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - adjustments to URL redirect to support urls without index.html (root) ([#163](https://github.com/adobe/leonardo/issues/163)) ([6bc0f21](https://github.com/adobe/leonardo/commit/6bc0f217fc7b9612d99e5e68beaa06153a68d0b7))
 - bugs in XML, SVG color outputs for scales. Removed console.logs ([42e4a15](https://github.com/adobe/leonardo/commit/42e4a1526d8c3fb9538ba60c52aa050db0bffc8a))
 - clean dist before deploy ([7eab1c3](https://github.com/adobe/leonardo/commit/7eab1c37d263f371bb505d06fa072f990c20cba3))
-- corrected URL redirect for backwards compatability ([#157](https://github.com/adobe/leonardo/issues/157)) ([a4c206d](https://github.com/adobe/leonardo/commit/a4c206d69d770c391b763832a635ae44eb521081))
+- corrected URL redirect for backwards compatibility ([#157](https://github.com/adobe/leonardo/issues/157)) ([a4c206d](https://github.com/adobe/leonardo/commit/a4c206d69d770c391b763832a635ae44eb521081))
 - update gh-pages so deploy deletes old files ([#158](https://github.com/adobe/leonardo/issues/158)) ([165ebaa](https://github.com/adobe/leonardo/commit/165ebaae847eeca20d22cac47fc4925c5ff1cfe0))
 
 # [1.4.0](https://github.com/adobe/leonardo/compare/@adobe/leonardo-ui@1.3.7...@adobe/leonardo-ui@1.4.0) (2022-08-09)
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - adjustments to URL redirect to support urls without index.html (root) ([#163](https://github.com/adobe/leonardo/issues/163)) ([6bc0f21](https://github.com/adobe/leonardo/commit/6bc0f217fc7b9612d99e5e68beaa06153a68d0b7))
 - bugs in XML, SVG color outputs for scales. Removed console.logs ([42e4a15](https://github.com/adobe/leonardo/commit/42e4a1526d8c3fb9538ba60c52aa050db0bffc8a))
 - clean dist before deploy ([7eab1c3](https://github.com/adobe/leonardo/commit/7eab1c37d263f371bb505d06fa072f990c20cba3))
-- corrected URL redirect for backwards compatability ([#157](https://github.com/adobe/leonardo/issues/157)) ([a4c206d](https://github.com/adobe/leonardo/commit/a4c206d69d770c391b763832a635ae44eb521081))
+- corrected URL redirect for backwards compatibility ([#157](https://github.com/adobe/leonardo/issues/157)) ([a4c206d](https://github.com/adobe/leonardo/commit/a4c206d69d770c391b763832a635ae44eb521081))
 - update gh-pages so deploy deletes old files ([#158](https://github.com/adobe/leonardo/issues/158)) ([165ebaa](https://github.com/adobe/leonardo/commit/165ebaae847eeca20d22cac47fc4925c5ff1cfe0))
 
 ### Features


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `docs/ui/CHANGELOG.md`

## Testing
I run `git diff --check`.
