### PR TITLE
fix: restore docs UI pages blanked by broken ESM imports

### DIFF
--- a/docs/ui/src/home.js
+++ b/docs/ui/src/home.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import './index.css';
-import {pageLoader} from './js/pageLoader';
+import {schedulePageLoader} from './js/pageLoader';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import bash from 'highlight.js/lib/languages/bash';
@@ -57,9 +57,15 @@ function highlightDocsSideNav() {
   }
 }
 
-window.addEventListener('load', () => {
+function initHomePage() {
   highlightHeaderTab();
   highlightDocsSideNav();
   hljs.highlightAll();
-  pageLoader();
-});
+  schedulePageLoader();
+}
+
+if (document.readyState === 'complete') {
+  initHomePage();
+} else {
+  window.addEventListener('load', initHomePage, {once: true});
+}

--- a/docs/ui/src/js/colorDetailsPanel.js
+++ b/docs/ui/src/js/colorDetailsPanel.js
@@ -20,7 +20,7 @@ import {createRGBchannelChart} from './createRGBchannelChart';
 import {baseScaleOptions} from './createBaseScaleOptions';
 import {openDetailTab} from './tabs';
 import {createDetailOutputColors} from './createOutputColors';
-import {_theme, _colorScales} from './initialTheme';
+import {_theme} from './initialTheme';
 import {downloadSVGgradient} from './createSVGgradient';
 import {create3dModel} from './create3dModel';
 import {createColorWheel, updateColorDots, updateColorWheel} from './colorWheel';

--- a/docs/ui/src/js/createSVGuiKit.js
+++ b/docs/ui/src/js/createSVGuiKit.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 import {saveAs} from 'file-saver';
 import d3 from './d3';
-import {_theme, _themeTypography} from './initialTheme';
+import {_theme} from './initialTheme';
 import {getThemeName, getContrastRatioInputs} from './getThemeData';
 import {capitalizeFirstLetter} from './utils';
 

--- a/docs/ui/src/js/getThemeData.js
+++ b/docs/ui/src/js/getThemeData.js
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import {getLightness} from './utils';
-import {_theme, _colorScales} from './initialTheme';
+import {_theme} from './initialTheme';
 
 window.getColorClassById = getColorClassById;
 function getColorClassById(id) {

--- a/docs/ui/src/js/pageLoader.js
+++ b/docs/ui/src/js/pageLoader.js
@@ -16,14 +16,34 @@ function pageLoader() {
 
   if (page) {
     page.style.transition = `opacity ${transitionMs}ms ease-out`;
+    // Commit the starting opacity before transitioning to 1.
+    void page.offsetWidth;
     page.style.opacity = '1';
   }
 
   if (loader) {
     loader.style.transition = `opacity ${transitionMs}ms ease-out`;
+    void loader.offsetWidth;
     loader.style.opacity = '0';
-    setTimeout(() => loader.remove(), transitionMs + 50);
+  }
+
+  // Finish reveal even if the opacity transition never advances (throttled tabs).
+  setTimeout(() => {
+    if (page) {
+      page.style.transition = 'none';
+      page.style.opacity = '1';
+    }
+    loader?.remove();
+  }, transitionMs + 50);
+}
+
+/** Reveal the page after modules load, even if `window` `load` already fired. */
+function schedulePageLoader() {
+  if (document.readyState === 'complete') {
+    pageLoader();
+  } else {
+    window.addEventListener('load', pageLoader, {once: true});
   }
 }
 
-export {pageLoader};
+export {pageLoader, schedulePageLoader};

--- a/docs/ui/src/js/ratios.js
+++ b/docs/ui/src/js/ratios.js
@@ -17,7 +17,6 @@ import {createOutputColors} from './createOutputColors';
 import {createOutputParameters} from './createOutputParameters';
 import {createRatioChart, createLuminosityChart} from './createRatioChart';
 import {randomId, round, lerp} from './utils';
-import {difference} from 'd3';
 
 function addRatio() {
   let wcagFormula = document.getElementById('themeWCAG').value;

--- a/docs/ui/src/scales.js
+++ b/docs/ui/src/scales.js
@@ -66,7 +66,7 @@ import './scss/components/toast.scss';
 import './scss/components/tooltip.scss';
 
 import '@adobe/focus-ring-polyfill';
-import {pageLoader} from './js/pageLoader';
+import {schedulePageLoader} from './js/pageLoader';
 
 import * as Leo from '@adobe/leonardo-contrast-colors';
 import loadIcons from 'loadicons';
@@ -85,7 +85,7 @@ import {colorScaleDiverging} from './js/colorScaleDiverging';
 import {colorScaleSequential} from './js/colorScaleSequential';
 import {colorScaleQualitative} from './js/colorScaleQualitative';
 
-import toggleTooltip from './js/tooltip';
+import './js/tooltip';
 import {create3dModel} from './js/create3dModel';
 import {createSVGswatches, downloadSwatches} from './js/createSVGswatches';
 import {createXML, downloadXML} from './js/createXML';
@@ -125,12 +125,4 @@ colorScaleSequential();
 colorScaleDiverging();
 colorScaleQualitative();
 
-window.onload = function () {
-  // let uri = window.location.toString();
-  // let cleanURL = uri.substring(0, uri.indexOf("?"));
-
-  // window.history.replaceState({}, document.title, cleanURL);
-
-  // On window load, transition to remove page loader
-  pageLoader();
-};
+schedulePageLoader();

--- a/docs/ui/src/theme.js
+++ b/docs/ui/src/theme.js
@@ -87,14 +87,13 @@ import {addLightnessBulk, bulkLightnessInput, cancelLightnessBulk} from './js/ad
 import {clearAllColors} from './js/keyColors';
 import {showToast, hideToast, exitPreview, neverShowToast} from './js/toast';
 import {addFromURL, addFromURLDialog, cancelURL} from './js/addFromURL';
-import updateThemeTitle from './js/themeTitle';
+import './js/themeTitle';
 import {addRatio, sortRatios} from './js/ratios';
 import {openPanelTab, openTab, openDetailTab, openAppTab, openColorTab} from './js/tabs';
-import toggleTooltip from './js/tooltip';
+import './js/tooltip';
 import {downloadUiKit, createSVGuiKit} from './js/createSVGuiKit';
-import {toggleSwatchAttributes} from './js/toggleSwatchAttributes';
-import {pageLoader} from './js/pageLoader';
-import {format} from 'path';
+import './js/toggleSwatchAttributes';
+import {schedulePageLoader} from './js/pageLoader';
 import {create3dModel} from './js/create3dModel';
 import {sortColorScales} from './js/sortColorScales';
 import {togglePopover} from './js/popover';
@@ -176,6 +175,4 @@ document.getElementById('tabPalette').click();
 document.getElementById('tabContrastingPairs').click();
 document.getElementById('tabColorWheel').click();
 
-window.onload = function () {
-  pageLoader();
-};
+schedulePageLoader();

--- a/docs/ui/src/tools.js
+++ b/docs/ui/src/tools.js
@@ -64,7 +64,7 @@ import './scss/components/toast.scss';
 import './scss/components/tooltip.scss';
 
 import '@adobe/focus-ring-polyfill';
-import {pageLoader} from './js/pageLoader';
+import {schedulePageLoader} from './js/pageLoader';
 
 import loadIcons from 'loadicons';
 loadIcons('./spectrum-css-icons.svg');
@@ -73,9 +73,9 @@ loadIcons('./spectrum-icons.svg');
 // Import local Javascript functions
 import {throttle} from './js/utils';
 import {openPanelTab, openTab, openAppTab} from './js/tabs';
-import toggleTooltip from './js/tooltip';
+import './js/tooltip';
 import {compareColors} from './js/compareColors';
-import {convertColors} from './js/convertColors';
+import './js/convertColors';
 import {bulkConvert, bulkItemConvertColorInput, cancelBulkConvert} from './js/bulkConvertDialog';
 
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (event) => {
@@ -106,7 +106,4 @@ document.getElementById('compareColorTwoInput').dispatchEvent(new Event('input')
 
 document.getElementById('convertColorOneInput').dispatchEvent(new Event('input'));
 
-window.onload = function () {
-  // On window load, transition to remove page loader
-  pageLoader();
-};
+schedulePageLoader();


### PR DESCRIPTION
Invalid named/default imports crashed theme, scales, and tools before pageLoader could reveal #page.

<!-- Summarize your changes in the Title field -->

## Description

<!--
  Note: Before sending a pull request, make sure there's an issue for what you're changing
   - Search for issues: https://github.com/adobe/leonardo/issues
   - If there's no issue, file it: https://github.com/adobe/leonardo/issues/new/choose
-->
<!-- Describe what you changed and link to the relevant issue(s) -->

## Motivation

<!-- How do your changes support this project's goals? -->

## Screenshots

<!-- If applicable, add screenshots to show what you changed -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [ ] This pull request is ready to merge.
